### PR TITLE
Fix multi threading issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,7 @@ strings](#uri-templates-lolwut). It's useful for helping yourself generate the
 Add it to your Gemfile:
 
 ```ruby
-gem 'zooplankton', require: false
-```
-
-It's important that you use `require: false`. This is because Zooplankton needs to be loaded _after_ the Rails application has been defined.
-
-Now require it in an initializer in your Rails app, ex. `config/initializers/zooplankton.rb`
-
-```ruby
-require 'zooplankton'
+gem 'zooplankton'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Zooplankton is a library for helping you turn Rails routes into [URI Template
 strings](#uri-templates-lolwut). It's useful for helping yourself generate the
 `_links` part of [HAL](http://stateless.co/hal_specification.html), for example.
 
+## Installation
+
+Add it to your Gemfile:
+
+```ruby
+gem 'zooplankton', require: false
+```
+
+It's important that you use `require: false`. This is because Zooplankton needs to be loaded _after_ the Rails application has been defined.
+
+Now require it in an initializer in your Rails app, ex. `config/initializers/zooplankton.rb`
+
+```ruby
+require 'zooplankton'
+```
+
 ## Usage
 
 Given a route file like this:

--- a/lib/zooplankton.rb
+++ b/lib/zooplankton.rb
@@ -1,16 +1,22 @@
+require "rails"
 require "zooplankton/version"
-require "zooplankton/parser"
 
 module Zooplankton
-  class << self
-    @@parser = Parser.new
+  def self.setup!
+    require "zooplankton/parser"
 
-    def path_template_for(helper_name, query_params = {}, supplied_params = nil)
-      @@parser.path_template_for(helper_name, query_params, supplied_params)
-    end
+    module_eval do
+      @@parser = Parser.new
 
-    def url_template_for(helper_name, query_params = {}, supplied_params = nil)
-      @@parser.url_template_for(helper_name, query_params, supplied_params)
+      def self.path_template_for(helper_name, query_params = {}, supplied_params = nil)
+        @@parser.path_template_for(helper_name, query_params, supplied_params)
+      end
+
+      def self.url_template_for(helper_name, query_params = {}, supplied_params = nil)
+        @@parser.url_template_for(helper_name, query_params, supplied_params)
+      end
     end
   end
 end
+
+require "zooplankton/railtie" if defined?(::Rails)

--- a/lib/zooplankton/parser.rb
+++ b/lib/zooplankton/parser.rb
@@ -1,10 +1,13 @@
-require "rails"
 require "zooplankton/resolver"
 
 module Zooplankton
   class Parser
     AMPERSAND = '&'.freeze
     QUESTION_MARK = '?'.freeze
+
+    def initialize(resolver = Resolver.instance)
+      @resolver = resolver
+    end
 
     def path_template_for(helper_name, query_params={}, supplied_params=nil)
       build_template(:path, helper_name, *parse_params(query_params, supplied_params))
@@ -15,6 +18,7 @@ module Zooplankton
     end
 
     private
+    attr_reader :resolver
 
     def parse_params(*args)
       if args.first.respond_to?(:to_h) && !args.first.is_a?(Array)
@@ -66,10 +70,6 @@ module Zooplankton
       helper_method = "#{helper_name}_#{path_or_url}"
 
       resolver.generate(helper_method, helper_name, params)
-    end
-
-    def resolver
-      @resolver ||= Resolver.instance
     end
 
     def escaped_pair(key, value)

--- a/lib/zooplankton/railtie.rb
+++ b/lib/zooplankton/railtie.rb
@@ -1,0 +1,7 @@
+module Zooplankton
+  class Railtie < Rails::Railtie
+    config.to_prepare do
+      Zooplankton.setup!
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,6 @@ end
 require 'zooplankton'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,25 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+#
+# A Rails app needs to be defined _before_ requiring this gem
+require "rails"
+module Plankton
+  class Application < Rails::Application
+  end
+end
+
+Plankton::Application.routes.tap do |routes|
+  routes.default_url_options[:host] = 'http://example.com'
+  routes.draw do
+    root 'root#index'
+    get '/post/:slug', to: 'posts#show', as: :post
+    get '/post/:slug/comment/:comment_id', to: 'commendts#show', as: :comment
+  end
+end
+
+require 'zooplankton'
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true

--- a/spec/zooplankton_spec.rb
+++ b/spec/zooplankton_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+Zooplankton.setup!
 
 describe Zooplankton do
   describe ".path_template_for" do

--- a/spec/zooplankton_spec.rb
+++ b/spec/zooplankton_spec.rb
@@ -1,19 +1,4 @@
 require 'spec_helper'
-require 'zooplankton'
-
-module Plankton
-  class Application < Rails::Application
-  end
-end
-
-Plankton::Application.routes.tap do |routes|
-  routes.default_url_options[:host] = 'http://example.com'
-  routes.draw do
-    root 'root#index'
-    get '/post/:slug', to: 'posts#show', as: :post
-    get '/post/:slug/comment/:comment_id', to: 'commendts#show', as: :comment
-  end
-end
 
 describe Zooplankton do
   describe ".path_template_for" do

--- a/zooplankton.gemspec
+++ b/zooplankton.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rspec", "~> 3.6"
 
   spec.add_dependency "rails", [">= 4.0", "< 6.0"]
 end


### PR DESCRIPTION
## What

This PR pre-loads Rails' URL helpers into a module on startup time, to prevent multi-threading issues (ex. Puma) documented here: https://github.com/puma/puma/issues/647

## Context

I encountered sporadic issues when running this as part of a production app.

<img width="483" alt="screen shot 2017-08-10 at 14 43 57" src="https://user-images.githubusercontent.com/1081/29173179-65eff708-7dda-11e7-8d61-a72e9096e792.png">

After some digging, everything points to the issue linked to above. The solution is to pre-load Rails' route helpers into a module instead of accessing them in run time.

This has the side benefit of improving performance (see below).

## Installation

Unfortunately, this change means that Zooplankton needs to be required _after_ the Rails application and routes have been defined. So you need this in your Gemfile:

```ruby
gem 'zooplankton', require: false
```

And then require the gem in an initializer

```ruby
# config/initializers/zooplankton.rb
require 'zooplankton'
```

## Performance

Calling `Rails.application.routes.url_helpers` directly seems to create a new module every time, which is slow. The solution is to `include Rails.application.routes.url_helpers` once at startup time into our own module, and use that module in the library.

I run a quick benchmark before and after this change.

```
# before
#       user     system      total        real
#   0.250000   0.000000   0.250000 (  0.250181)
```
```
# after
#       user     system      total        real
#   0.110000   0.000000   0.110000 (  0.114176)
```

So there seems to be a performance gain.

This is the benchmark script used (Ruby 2.3.1 on a MacBook Pro 3 GHz Intel Core i7, 16 GB 1600 MHz DDR3):

```ruby
require 'bundler/setup'
require 'rails'
require 'benchmark'

module Plankton
  class Application < Rails::Application
  end
end

Plankton::Application.routes.tap do |routes|
  routes.default_url_options[:host] = 'http://example.com'
  routes.draw do
    root 'root#index'
    get '/post/:slug', to: 'posts#show', as: :post
    get '/post/:slug/comment/:comment_id', to: 'commendts#show', as: :comment
  end
end

require_relative './lib/zooplankton'

Benchmark.bmbm do |x|
  x.report do
    1.upto(1000) do
      Zooplankton.path_template_for(:post)
      Zooplankton.path_template_for(:comment, slug: 'foo')
    end
  end
end
```
